### PR TITLE
[DEVO-2330] Use config files in jenkins for credentials and other values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # Example project for Jenkins Pipeline for Rocket Workflow Promotions
+
+This project will be deployed in customers that need to use the CICD pipeline to promote the Rocket Workflow from one environment to another.
+
+# Prerequisites
+
+It is assumed that you have the following prerequisites:
+- A working Jenkins instance
+- A working Rocket Workflow instance
+- A working Rocket Workflow project
+- A working Rocket Workflow environment
+- A Jenkins secret containing the username and password for the Rocket Workflow instance (one per environment)
+- Optional: A file in Jenkins that contains a yaml with the structure
+```
+  
+    "https://rocket.env.client/rocket/": "credential_env_id"
+    "https://rocket.env2.client/rocket/": "credential_env2_id"
+    "MAVEN_PLUGIN_VERSION" : "version xx"
+  
+```
+
+# Values override
+Some default values can be overrided by using the rocket yaml configuration file, but if the file is not provided defaults will be used.
+
+Overridable default values:
+- SLEEP_TIME
+- MAVEN_PLUGIN_VERSION
+

--- a/vars/doAutoML2envs.groovy
+++ b/vars/doAutoML2envs.groovy
@@ -2,121 +2,109 @@
 
 def call(Map props = [:]) {
 
-    def NODE = props["JENKINS_NODE_NAME"] ? props["JENKINS_NODE_NAME"] : "jenkins-slave-mvn-jdk11"
+    // Load all the variables into the environment
+    initializeVariables(props)
 
-    node(NODE) {
+    node(env.NODE) {
 
         println("Rocket flow for AutoML 2 envs")
 
-        def ROCKET_URL = props["ROCKET_API_URL_DEV"]
-        def ROCKET_TENANT = props["ROCKET_TENANT_DEV"]
-
-        def ROCKET_TARGET_URL = props["ROCKET_API_URL_PRO"]
-        def ROCKET_TARGET_TENANT = props["ROCKET_TENANT_PRO"]
-
-        def ASSET_VERSION_ID = props["assetVersionId"]
-        def RELEASE_ID = props["releaseId"]
-        def ARCHIVE_PATH = "${BUILD_TAG}.zip"
-        def MAVEN_PLUGIN_VERSION = props["MAVEN_PLUGIN_VERSION"] ? props["MAVEN_PLUGIN_VERSION"] : "1.1.0-d3ffff0"
-        def CONNECT_TIMEOUT = props["CONNECT_TIMEOUT"] ? props["CONNECT_TIMEOUT"] : "2000"
-        def READ_TIMEOUT = props["READ_TIMEOUT"] ? props["READ_TIMEOUT"] : "10000"
-
 
         stage('Init release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DbuildUrl=$BUILD_URL -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DbuildUrl=$env.BUILD_URL -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check prod instance') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS_ID, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check asset dependencies') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS_ID, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Export asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DexportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DexportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
-            archiveArtifacts artifacts: "${ARCHIVE_PATH}"
+            archiveArtifacts artifacts: "${env.ARCHIVE_PATH}"
         }
 
-        sleep(time: sleep_time, unit: "SECONDS")
+        sleep(time: env.SLEEP_TIME, unit: "SECONDS")
 
         stage('Import asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS_ID, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DimportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DimportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Set released') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Lock origin') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
         stage('Lock target') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS_ID, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Finalize release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS_ID, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }

--- a/vars/doMLModel2envs.groovy
+++ b/vars/doMLModel2envs.groovy
@@ -2,121 +2,110 @@
 
 def call(Map props = [:]) {
 
-    def NODE = props["JENKINS_NODE_NAME"] ? props["JENKINS_NODE_NAME"] : "jenkins-slave-mvn-jdk11"
+    // Load all the variables into the environment
+    initializeVariables(props)
 
-    node(NODE) {
+    node(env.NODE) {
 
         println("Rocket flow for MLModel 2 envs")
 
-        def ROCKET_URL = props["ROCKET_API_URL_DEV"]
-        def ROCKET_TENANT = props["ROCKET_TENANT_DEV"]
-
-        def ROCKET_TARGET_URL = props["ROCKET_API_URL_PRO"]
-        def ROCKET_TARGET_TENANT = props["ROCKET_TENANT_PRO"]
-
-        def ASSET_VERSION_ID = props["assetVersionId"]
-        def RELEASE_ID = props["releaseId"]
-        def ARCHIVE_PATH = "${BUILD_TAG}.zip"
-        def MAVEN_PLUGIN_VERSION = props["MAVEN_PLUGIN_VERSION"] ? props["MAVEN_PLUGIN_VERSION"] : "1.1.0-d3ffff0"
-        def CONNECT_TIMEOUT = props["CONNECT_TIMEOUT"] ? props["CONNECT_TIMEOUT"] : "2000"
-        def READ_TIMEOUT = props["READ_TIMEOUT"] ? props["READ_TIMEOUT"] : "10000"
 
 
         stage('Init release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DbuildUrl=$BUILD_URL -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DbuildUrl=$env.BUILD_URL -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check prod instance') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check asset dependencies') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Export asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DexportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DexportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
-            archiveArtifacts artifacts: "${ARCHIVE_PATH}"
+            archiveArtifacts artifacts: "${env.ARCHIVE_PATH}"
         }
 
-        sleep(time: sleep_time, unit: "SECONDS")
+        sleep(time: env.SLEEP_TIME, unit: "SECONDS")
 
         stage('Import asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DimportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DimportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Set released') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Lock origin') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
         stage('Lock target') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_TARGET_CREDENTIALS, usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Finalize release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }

--- a/vars/doMLProject2envs.groovy
+++ b/vars/doMLProject2envs.groovy
@@ -2,121 +2,106 @@
 
 def call(Map props = [:]) {
 
-    def NODE = props["JENKINS_NODE_NAME"] ? props["JENKINS_NODE_NAME"] : "jenkins-slave-mvn-jdk11"
-
-    node(NODE) {
-
-        println("Rocket flow for MLProject 2 envs")
-
-        def ROCKET_URL = props["ROCKET_API_URL_DEV"]
-        def ROCKET_TENANT = props["ROCKET_TENANT_DEV"]
-
-        def ROCKET_TARGET_URL = props["ROCKET_API_URL_PRO"]
-        def ROCKET_TARGET_TENANT = props["ROCKET_TENANT_PRO"]
-
-        def ASSET_VERSION_ID = props["assetVersionId"]
-        def RELEASE_ID = props["releaseId"]
-        def ARCHIVE_PATH = "${BUILD_TAG}.zip"
-        def MAVEN_PLUGIN_VERSION = props["MAVEN_PLUGIN_VERSION"] ? props["MAVEN_PLUGIN_VERSION"] : "1.1.0-d3ffff0"
-        def CONNECT_TIMEOUT = props["CONNECT_TIMEOUT"] ? props["CONNECT_TIMEOUT"] : "2000"
-        def READ_TIMEOUT = props["READ_TIMEOUT"] ? props["READ_TIMEOUT"] : "10000"
-
+    // Load all the variables into the environment
+    initializeVariables(props)
+    node(env.NODE) {
+  
 
         stage('Init release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DbuildUrl=$BUILD_URL -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DbuildUrl=$env.BUILD_URL -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check prod instance') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check asset dependencies') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Export asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DexportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DexportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
-            archiveArtifacts artifacts: "${ARCHIVE_PATH}"
+            archiveArtifacts artifacts: "${env.ARCHIVE_PATH}"
         }
 
-        sleep(time: sleep_time, unit: "SECONDS")
+        sleep(time: env.SLEEP_TIME, unit: "SECONDS")
 
         stage('Import asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DimportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DimportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Set released') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Lock origin') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
         stage('Lock target') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Finalize release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }

--- a/vars/doMLTrainer2envs.groovy
+++ b/vars/doMLTrainer2envs.groovy
@@ -2,121 +2,109 @@
 
 def call(Map props = [:]) {
 
-    def NODE = props["JENKINS_NODE_NAME"] ? props["JENKINS_NODE_NAME"] : "jenkins-slave-mvn-jdk11"
+    // Load all the variables into the environment
+    initializeVariables(props)
 
-    node(NODE) {
+    node(env.NODE) {
 
         println("Rocket flow for MLTrainer 2 envs")
 
-        def ROCKET_URL = props["ROCKET_API_URL_DEV"]
-        def ROCKET_TENANT = props["ROCKET_TENANT_DEV"]
-
-        def ROCKET_TARGET_URL = props["ROCKET_API_URL_PRO"]
-        def ROCKET_TARGET_TENANT = props["ROCKET_TENANT_PRO"]
-
-        def ASSET_VERSION_ID = props["assetVersionId"]
-        def RELEASE_ID = props["releaseId"]
-        def ARCHIVE_PATH = "${BUILD_TAG}.zip"
-        def MAVEN_PLUGIN_VERSION = props["MAVEN_PLUGIN_VERSION"] ? props["MAVEN_PLUGIN_VERSION"] : "1.1.0-d3ffff0"
-        def CONNECT_TIMEOUT = props["CONNECT_TIMEOUT"] ? props["CONNECT_TIMEOUT"] : "2000"
-        def READ_TIMEOUT = props["READ_TIMEOUT"] ? props["READ_TIMEOUT"] : "10000"
-
 
         stage('Init release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DbuildUrl=$BUILD_URL -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DbuildUrl=$env.BUILD_URL -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check prod instance') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check asset dependencies') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Export asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DexportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DexportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
-            archiveArtifacts artifacts: "${ARCHIVE_PATH}"
+            archiveArtifacts artifacts: "${env.ARCHIVE_PATH}"
         }
 
-        sleep(time: sleep_time, unit: "SECONDS")
+        sleep(time: env.SLEEP_TIME, unit: "SECONDS")
 
         stage('Import asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DimportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DimportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Set released') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Lock origin') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
         stage('Lock target') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Finalize release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }

--- a/vars/doWorkflow2envs.groovy
+++ b/vars/doWorkflow2envs.groovy
@@ -2,132 +2,120 @@
 
 def call(Map props = [:]) {
 
-    def NODE = props["JENKINS_NODE_NAME"] ? props["JENKINS_NODE_NAME"] : "jenkins-slave-mvn-jdk11"
+    // Load all the variables into the environment
+    initializeVariables(props)
 
-    node(NODE) {
+    node(env.NODE) {
 
         println("Rocket flow for workflow 2 envs")
 
-        def sleep_time = 4
 
-        def ROCKET_URL = props["ROCKET_API_URL_DEV"]
-        def ROCKET_TENANT = props["ROCKET_TENANT_DEV"]
-
-        def ROCKET_TARGET_URL = props["ROCKET_API_URL_PRO"]
-        def ROCKET_TARGET_TENANT = props["ROCKET_TENANT_PRO"]
-
-        def ASSET_VERSION_ID = props["assetVersionId"]
-        def RELEASE_ID = props["releaseId"]
-        def ARCHIVE_PATH = "${BUILD_TAG}.zip"
-        def MAVEN_PLUGIN_VERSION = props["MAVEN_PLUGIN_VERSION"] ? props["MAVEN_PLUGIN_VERSION"] : "1.1.0-d3ffff0"
-        def CONNECT_TIMEOUT = props["CONNECT_TIMEOUT"] ? props["CONNECT_TIMEOUT"] : "2000"
-        def READ_TIMEOUT = props["READ_TIMEOUT"] ? props["READ_TIMEOUT"] : "10000"
 
         stage('Init release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DbuildUrl=$BUILD_URL -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:init -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DbuildUrl=$env.BUILD_URL -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check prod instance') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkEnv -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Validate workflow') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:validate -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:validate -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Check asset dependencies') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:checkDependencies -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Export asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DexportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:exportAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DexportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
-            archiveArtifacts artifacts: "${ARCHIVE_PATH}"
+            archiveArtifacts artifacts: "${env.ARCHIVE_PATH}"
         }
 
-        sleep(time: sleep_time, unit: "SECONDS")
+        sleep(time: env.SLEEP_TIME, unit: "SECONDS")
 
         stage('Import asset') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DassetVersionId=$ASSET_VERSION_ID -DreleaseId=$RELEASE_ID -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DimportPath=$ARCHIVE_PATH -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:importAsset -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DassetVersionId=$env.ASSET_VERSION_ID -DreleaseId=$env.RELEASE_ID -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DimportPath=$env.ARCHIVE_PATH -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Set released') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:setAssetState -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DassetState='Release' -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Lock origin') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
         stage('Lock target') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
                 withCredentials([
-                        [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
+                        [$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS'],
                         [$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS_TARGET", usernameVariable: 'ROCKET_TARGET_USER', passwordVariable: 'ROCKET_TARGET_PASS']
                 ]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DtargetEnvBaseUrl=$ROCKET_TARGET_URL -DtargetEnvUser=$ROCKET_TARGET_USER -DtargetEnvPassword=$ROCKET_TARGET_PASS -DtargetEnvTenant=$ROCKET_TARGET_TENANT -DreleaseId=$RELEASE_ID -DassetVersionId=$ASSET_VERSION_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:lockAssetVersion -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DtargetEnvBaseUrl=$env.ROCKET_TARGET_URL -DtargetEnvUser=$env.ROCKET_TARGET_USER -DtargetEnvPassword=$env.ROCKET_TARGET_PASS -DtargetEnvTenant=$env.ROCKET_TARGET_TENANT -DreleaseId=$env.RELEASE_ID -DassetVersionId=$env.ASSET_VERSION_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }
 
-        sleep(time: sleep_time, unit:"SECONDS")
+        sleep(time: env.SLEEP_TIME, unit:"SECONDS")
 
         stage('Finalize release') {
-            configFileProvider([configFile(fileId: 'NexusMultiRepoSettings', variable: 'MAVEN_SETTINGS')]) {
-                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "ROCKET_AUTH_CREDENTIALS", usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
-                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$ROCKET_URL -Duser=$ROCKET_USER -Dpassword=$ROCKET_PASS -Dtenant=$ROCKET_TENANT -DreleaseId=$RELEASE_ID -DconnectTimeout=$CONNECT_TIMEOUT -DreadTimeout=$READ_TIMEOUT"
+            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_FILE, variable: 'MAVEN_SETTINGS')]) {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.ROCKET_ORIGIN_CREDENTIALS, usernameVariable: 'ROCKET_USER', passwordVariable: 'ROCKET_PASS']]) {
+                    sh "mvn -s $MAVEN_SETTINGS com.stratio.rocket:rocket-maven-plugin:${env.MAVEN_PLUGIN_VERSION}:finish -DrocketBaseUrl=$env.ROCKET_URL -Duser=$env.ROCKET_USER -Dpassword=$env.ROCKET_PASS -Dtenant=$env.ROCKET_TENANT -DreleaseId=$env.RELEASE_ID -DconnectTimeout=$env.CONNECT_TIMEOUT -DreadTimeout=$env.READ_TIMEOUT"
                 }
             }
         }

--- a/vars/initializeVariables.groovy
+++ b/vars/initializeVariables.groovy
@@ -1,0 +1,46 @@
+def call(Map props = [:]) {
+    return [
+        def parameters = promotion["release"]["parameters"]
+        def generalParams = parameters["General"]
+
+        env.NODE = generalParams?.JENKINS_NODE_NAME ?: "jenkins-slave-mvn-jdk11"
+
+
+        env.RELEASE_ID = promotion["releaseId"]
+
+        env.PUBLIC_JENKINS_URL = generalParams?.PUBLIC_JENKINS_URL
+        env.REPLACED_BUILD_URL = env.PUBLIC_JENKINS_URL ? env.BUILD_URL.replace(env.JENKINS_URL, PUBLIC_JENKINS_URL) : env.BUILD_URL
+
+
+        env.ROCKET_URL: props["ROCKET_API_URL_DEV"]
+        env.ROCKET_TENANT: props["ROCKET_TENANT_DEV"]
+
+        env.ROCKET_TARGET_URL: props["ROCKET_API_URL_PRO"]
+        env.ROCKET_TARGET_TENANT: props["ROCKET_TENANT_PRO"]
+        env.TARGET_PROJECT_NAME = generalParams?.TARGET_PROJECT_NAME ?: ""
+
+
+
+        def rocketConfig = [:] // Empty map to avoid null pointer exceptions
+
+        try  {
+            configFileProvider([configFile(fileId: 'rocketdict', variable: 'rocketdict')]) {
+                // Read the config file, if it does not exist, use an empty dict
+                 rocketConfig = readYaml file: rocketdict
+            }
+        } catch (e) {
+            echo "Unable to get and parse rocketdict file from the Config File Provider plugin. Using default values..."
+        }
+
+        env.ROCKET_ORIGIN_CREDENTIALS_ID = rocketConfig.get(ROCKET_URL, 'rocket-auth-credentials')
+        env.ROCKET_TARGET_CREDENTIALS_ID = rocketConfig.get(ROCKET_TARGET_URL, 'rocket-auth-credentials-target')
+        env.MAVEN_SETTINGS_FILE = rocketConfig.get(MAVEN_SETTINGS, 'NexusMultiRepoSettings')
+
+        env.ASSET_VERSION_ID: props["assetVersionId"]
+        env.RELEASE_ID: props["releaseId"]
+        env.ARCHIVE_PATH: "${BUILD_TAG}.zip"
+        env.MAVEN_PLUGIN_VERSION: rocketConfig["MAVEN_PLUGIN_VERSION"] ? props["MAVEN_PLUGIN_VERSION"] ? props["MAVEN_PLUGIN_VERSION"] : "1.1.0-d3ffff0"
+        env.CONNECT_TIMEOUT: props["CONNECT_TIMEOUT"] ? props["CONNECT_TIMEOUT"] : "2000"
+        env.READ_TIMEOUT: props["READ_TIMEOUT"] ? props["READ_TIMEOUT"] : "10000"
+        env.SLEEP_TIME = rocketConfig?[SLEEP_TIME] ? generalParams?.SLEEP_TIME ?: 4
+}


### PR DESCRIPTION
In this Pull Request the changes done are:
- We reduce code reiteration by using a single file that  manages the variables used in the pipeline and stores them in the env
- We read, if it exists, a config file in jenkins with rocket data. This allows to promote between more than two environments.
- We set additional values that can be customized inside the rocket config file
- We update the README.md with some meaningful information